### PR TITLE
#29

### DIFF
--- a/src/main/java/com/beanions/common/dto/FilePathDTO.java
+++ b/src/main/java/com/beanions/common/dto/FilePathDTO.java
@@ -1,0 +1,18 @@
+package com.beanions.common.dto;
+
+import lombok.*;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+@Component
+public class FilePathDTO {
+
+    private String directoryPath;
+
+}

--- a/src/main/java/com/beanions/common/service/SignupService.java
+++ b/src/main/java/com/beanions/common/service/SignupService.java
@@ -1,15 +1,51 @@
 package com.beanions.common.service;
 
 import com.beanions.common.dao.signup.SignupMapper;
+import com.beanions.common.dto.FilePathDTO;
 import com.beanions.common.dto.MembersDTO;
 import lombok.AllArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 @Service
 @AllArgsConstructor
+@EnableScheduling
 public class SignupService {
 
+    @Autowired
+    private FilePathDTO filePathDTO;
     private final SignupMapper signupMapper;
+
+    @Scheduled(fixedRate = 300000) // 매 1분마다 실행
+    public void deleteFile() {
+        Path directory = Path.of("C:\\Lecture\\Team-Beanions\\src\\main\\resources\\assets\\images\\upload\\user\\signupTemp");
+
+        if (directory != null && Files.isDirectory(directory)) {
+            try {
+                Files.walk(directory)
+                        .filter(Files::isRegularFile)
+                        .map(Path::toFile)
+                        .forEach(File::delete);
+                System.out.println("회원가입 이미지 임시저장 파일이 삭제되었습니다...");
+            } catch (Exception e) {
+                e.printStackTrace();
+                System.out.println("Error occurred while deleting files.");
+            }
+        } else {
+            System.out.println("Directory not found.");
+            File dir = new File(String.valueOf(directory));
+            if(!dir.exists()){
+                dir.mkdirs();
+                System.out.println("file make success!");
+            }
+        }
+    }
 
     public int checkDupId(String id) {
         return signupMapper.checkDupId(id);

--- a/src/main/resources/assets/js/signup.js
+++ b/src/main/resources/assets/js/signup.js
@@ -258,9 +258,9 @@ $(document).ready(function () {
             })
             .then(data => {
                 // 성공적인 응답을 처리한다.
-                console.log(data);
                 $("#fileName").val(data);
                 weddingVerified = data;
+                console.log(data);
             })
             .catch(error => {
                 // 오류가 발생했을 때 처리한다.
@@ -389,8 +389,8 @@ $(document).ready(function () {
                 .then(response => {
                     if (!response.ok) {
                         alert("회원가입이 실패하였습니다..")
+                        window.location.href="/signup";
                         throw new Error("Network response was not ok");
-                        return window.location.href="/signup";
                     }
                     alert("회원가입이 완료되었습니다! \n 로그인창으로 이동합니다..");
                     return window.location.href="/";


### PR DESCRIPTION
## 회원가입 기능

1. 회원가입 중 파일을 업로드는 했는데 가입을 하지 않았을 때, 회원전용 폴더에 계속 쌓이는 이슈 발생
> 용량 측면에서 악용될 우려가 있음

2. 회원가입 도중 업로드 된 파일을 기존:회원전용폴더 >> 변경:임시폴더에서 관리

3. @Scheduled 어노테이션 이용해서 일정시간(5분)이 지나면 서버가 자동으로 재시작되도록 설정

4. 이 로직에서 임시폴더의 내용을 전부 삭제하는 로직 추가

5. 성공적으로 회원가입등록 시, 임시폴더에 저장된 파일이 회원전용 파일로 이동하면서 임시폴더에 내용은 전부 삭제된다.

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
