### PR TITLE
[FEATURE][ADMIN] 관리자 메인페이지 예피셜 게시물 수 조회 & 로그인한 사용자 정보 헤더에 적용

### DIFF
--- a/src/main/java/com/beanions/admin/dto/AdminMainDTO.java
+++ b/src/main/java/com/beanions/admin/dto/AdminMainDTO.java
@@ -18,4 +18,8 @@ public class AdminMainDTO {
     private int yesinDay;
     private int yerangAll;
     private int yerangDay;
+    private int noticeAll;
+    private int noticeDay;
+    private int magazineAll;
+    private int magazineDay;
 }

--- a/src/main/resources/assets/css/admin/common.css
+++ b/src/main/resources/assets/css/admin/common.css
@@ -161,7 +161,15 @@ input::-webkit-search-results-decoration {
     border-right: 2px solid #EDEDFF;
 }
 
+#notice_count_box {
+    border-right: 2px solid #EDEDFF;
+}
+
 #yesin_margin {
+    margin-right: 10px;
+}
+
+#notice_margin {
     margin-right: 10px;
 }
 
@@ -169,7 +177,11 @@ input::-webkit-search-results-decoration {
     margin-left: 10px;
 }
 
-.second_main_content_box #free_line {
+#magazine_margin {
+    margin-left: 10px;
+}
+
+.second_main_content_box .free_line {
     width: 100%;
 }
 

--- a/src/main/resources/assets/css/admin/common.css
+++ b/src/main/resources/assets/css/admin/common.css
@@ -9,7 +9,7 @@ input::-webkit-search-results-decoration {
     display: none;
 }
 .container {
-    position: fixed; margin-top: 102px;
+    position: fixed; margin-top: 113px;
     width: 150px;
     border-right-style: solid;
     border-right-color: #6667AB;

--- a/src/main/resources/mapper/admin/AdminMapper.xml
+++ b/src/main/resources/mapper/admin/AdminMapper.xml
@@ -325,6 +325,10 @@
         <result property="yesinDay" column="yesin_day"/>
         <result property="yerangAll" column="yerang_all"/>
         <result property="yerangDay" column="yerang_day"/>
+        <result property="noticeAll" column="notice_all"/>
+        <result property="noticeDay" column="notice_day"/>
+        <result property="magazineAll" column="magazine_all"/>
+        <result property="magazineDay" column="magazine_day"/>
     </resultMap>
     <select id="selectAdminMainData" resultMap="selectAdminMainResultMap">
         SELECT
@@ -338,6 +342,10 @@
         , H.YESIN_DAY
         , I.YERANG_ALL
         , J.YERANG_DAY
+        , K.NOTICE_ALL
+        , L.NOTICE_DAY
+        , M.MAGAZINE_ALL
+        , N.MAGAZINE_DAY
         FROM
         (SELECT COUNT(*) MEMBER_ALL FROM MEMBERS) A
         , (SELECT COUNT(*) MEMBER_DAY FROM MEMBERS WHERE SIGNUP_DATE = CURDATE()) B
@@ -348,6 +356,10 @@
         , (SELECT COUNT(*) YESIN_ALL FROM POST WHERE SUB_CATEGORY = '예신') G
         , (SELECT COUNT(*) YESIN_DAY FROM POST WHERE SUB_CATEGORY = '예신' AND POST_DATE = CURDATE()) H
         , (SELECT COUNT(*) YERANG_ALL FROM POST WHERE SUB_CATEGORY = '예랑') I
-        , (SELECT COUNT(*) YERANG_DAY FROM POST WHERE SUB_CATEGORY = '예랑' AND POST_DATE = CURDATE()) J;
+        , (SELECT COUNT(*) YERANG_DAY FROM POST WHERE SUB_CATEGORY = '예랑' AND POST_DATE = CURDATE()) J
+        , (SELECT COUNT(*) NOTICE_ALL FROM POST WHERE MAIN_CATEGORY = '공지사항') K
+        , (SELECT COUNT(*) NOTICE_DAY FROM POST WHERE MAIN_CATEGORY = '공지사항' AND POST_DATE = CURDATE()) L
+        , (SELECT COUNT(*) MAGAZINE_ALL FROM POST WHERE MAIN_CATEGORY = '매거진') M
+        , (SELECT COUNT(*) MAGAZINE_DAY FROM POST WHERE MAIN_CATEGORY = '매거진' AND POST_DATE = CURDATE()) N;
     </select>
 </mapper>

--- a/src/main/resources/templates/admin/header.html
+++ b/src/main/resources/templates/admin/header.html
@@ -1,7 +1,17 @@
 <!DOCTYPE html>
 <html xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
-<div style="position: fixed; margin-left: 18px; margin-bottom: 18px; width: 100%; background-color: #ffffff; z-index: 2;">
-    <img th:src="@{/images/common/logo.svg}" alt="logo" height="60px" width="60px" style="margin-top: 18px; margin-bottom: 18px;">
-    <p sec:authorize="hasAnyAuthority('ADMIN')" sec:authentication="principal.loginUserDTO.nickname"></p>
-<hr style="background-color: #EDEDFF; height: 1px; border: 0">
+<div style="position: fixed; width: 100%; background-color: #ffffff; z-index: 2;">
+    <div style="display: flex; justify-content: space-between; padding: 20px">
+        <!-- 로고 이미지 -->
+        <img th:src="@{/images/common/logo.svg}" alt="logo" width="72px">
+        <!-- 관리자 닉네임 -->
+        <div style="display: flex; align-items: end; justify-content: space-evenly; width: 180px; font-size: 18px">
+            <img th:src="@{/images/common/icon_user_profile.svg}" style="width: 32px; height: 32px">
+            <div style="display: flex; justify-content: space-evenly; width: 140px; padding-bottom: 3px">
+                <p style="font-weight: var(--regular)">관리자</p>
+                <p sec:authorize="hasAnyAuthority('ADMIN')" sec:authentication="principal.loginUserDTO.nickname" style="font-weight: var(--semiBold)"></p>
+            </div>
+        </div>
+    </div>
+    <hr style="background-color: #EDEDFF; height: 1px; border: 0">
 </div>

--- a/src/main/resources/templates/admin/header.html
+++ b/src/main/resources/templates/admin/header.html
@@ -1,4 +1,7 @@
+<!DOCTYPE html>
+<html xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 <div style="position: fixed; margin-left: 18px; margin-bottom: 18px; width: 100%; background-color: #ffffff; z-index: 2;">
     <img th:src="@{/images/common/logo.svg}" alt="logo" height="60px" width="60px" style="margin-top: 18px; margin-bottom: 18px;">
+    <p sec:authorize="hasAnyAuthority('ADMIN')" sec:authentication="principal.loginUserDTO.nickname"></p>
 <hr style="background-color: #EDEDFF; height: 1px; border: 0">
 </div>

--- a/src/main/resources/templates/admin/main/dashBoard.html
+++ b/src/main/resources/templates/admin/main/dashBoard.html
@@ -111,11 +111,41 @@
                             </div>
                         </div>
                     </div>
-                    <hr id="free_line">
+                    <hr class="free_line">
                 </div>
             </div>
         </div>
-        <div class="dashBoard_board_box"></div>
+        <div class="dashBoard_board_box">
+            <p class="dashBoard_board_text">예피셜</p>
+            <div class="dashBoard_item_second">
+                <div class="second_main_content_box">
+                    <p class="content_header">&nbsp;</p>
+                    <div class="content_text_box">
+                        <div class="free_count_box" id="notice_count_box">
+                            <div class="free_content_count_box">
+                                <p>공지사항</p>
+                                <p class="number" th:text="${ data.noticeAll }"></p>
+                            </div>
+                            <div class="free_content_count_box" id="notice_margin">
+                                <p>신규</p>
+                                <p class="number" th:text="${ data.noticeDay }"></p>
+                            </div>
+                        </div>
+                        <div  class="free_count_box">
+                            <div class="free_content_count_box" id="magazine_margin">
+                                <p>매거진</p>
+                                <p class="number" th:text="${ data.magazineAll }"></p>
+                            </div>
+                            <div class="free_content_count_box">
+                                <p>신규</p>
+                                <p class="number" th:text="${ data.magazineDay }"></p>
+                            </div>
+                        </div>
+                    </div>
+                    <hr class="free_line">
+                </div>
+            </div>
+        </div>
     </div>
     <div class="dashBoard_box_third">
         <div class="dashBoard_table_area">


### PR DESCRIPTION
## #️⃣연관된 이슈

> #122

## 📝작업 내용

> * 관리자 메인페이지 예피셜(공지사항, 매거진) 게시글 수 조회
> * 로그인한 사용자 닉네임 헤더에 적용

### 스크린샷
![image](https://github.com/Team-Binions/Team-Binions/assets/155221216/e5db5f69-0d73-44c5-b14a-4834899a600f)

![image](https://github.com/Team-Binions/Team-Binions/assets/155221216/728ddbac-711d-4e79-8161-2cfc5893ad42)

