### PR TITLE
[FEATURE][SEARCH] 상세페이지 연결 및 CSS 적용

### DIFF
--- a/src/main/java/com/beanions/search/controller/SearchController.java
+++ b/src/main/java/com/beanions/search/controller/SearchController.java
@@ -41,6 +41,7 @@ public class SearchController {
 
         model.addAttribute("count", count);
         model.addAttribute("keyword", Keyword);
+        model.addAttribute("searchType", params.getSearchType());
         model.addAttribute("postList", postList);
 
         return "/user/search/result";

--- a/src/main/resources/assets/css/user/search.css
+++ b/src/main/resources/assets/css/user/search.css
@@ -1,2 +1,53 @@
 .wrapper {display: flex; flex-direction: column; align-items: center;}
 .search_cont {max-width: 1200px; width: 100%; min-height: calc(100vh - 200px); padding: 0 20px; font-family: 'Noto Sans KR';}
+
+/* ===== "키워드" 검색결과(개수) ===== */
+.keyword_result {
+    padding-top: 60px;
+    display: flex;
+    align-items: center;
+    font-weight: var(--bold);
+}
+.keyword_result p {
+    font-size: 24px;
+    padding-right: 10px;
+    color: var(--text-color);
+}
+.keyword_result span {
+    padding: 0 5px 0 5px;
+    border-radius: 12px;
+    /*width: 50px;*/
+    height: 30px;
+    text-align: center;
+    background-color: var(--main-color);
+    font-size: 20px;
+    font-family: 'Poppins';
+    color: #ffffff;
+}
+
+/* ===== 검색 유형 버튼 & 검색창 ===== */
+.searchType_searchBox {
+    display: flex;
+    padding-top: 60px;
+}
+.button_box {
+    padding-right: 10px;
+}
+.search-btn {
+    width: 88px;
+    height: 34px;
+    font-weight: var(--semiBold);
+    font-size: 16px;
+    border: 1px solid var(--main-color);
+    color: var(--main-color);
+    background-color: #ffffff;
+}
+.search-btn:hover {
+    color: #ffffff;
+}
+
+.search-btn.active {
+    background-color: var(--main-color);
+    color: #ffffff;
+    font-weight: var(--bold);
+}

--- a/src/main/resources/assets/css/user/search.css
+++ b/src/main/resources/assets/css/user/search.css
@@ -1,6 +1,23 @@
 .wrapper {display: flex; flex-direction: column; align-items: center;}
 .search_cont {max-width: 1200px; width: 100%; min-height: calc(100vh - 200px); padding: 0 20px; font-family: 'Noto Sans KR';}
 
+/* search input */
+input::-ms-clear,
+input::-ms-reveal {
+    display: none;
+}
+
+input::-webkit-search-decoration,
+input::-webkit-search-cancel-button,
+input::-webkit-search-results-button,
+input::-webkit-search-results-decoration {
+    display: none;
+}
+
+.eng {
+    font-family: 'Poppins';
+}
+
 /* ===== "키워드" 검색결과(개수) ===== */
 .keyword_result {
     padding-top: 60px;
@@ -13,15 +30,17 @@
     padding-right: 10px;
     color: var(--text-color);
 }
-.keyword_result span {
-    padding: 0 5px 0 5px;
-    border-radius: 12px;
+.post_count {
+    padding: 0 9px 0 9px;
+    border-radius: 20px;
     /*width: 50px;*/
     height: 30px;
     text-align: center;
     background-color: var(--main-color);
     font-size: 20px;
     font-family: 'Poppins';
+}
+.post_count span {
     color: #ffffff;
 }
 
@@ -29,7 +48,14 @@
 .searchType_searchBox {
     display: flex;
     padding-top: 60px;
+    justify-content: space-between;
 }
+
+.buttons_outline {
+    display: flex;
+    align-items: end;
+}
+
 .button_box {
     padding-right: 10px;
 }
@@ -49,5 +75,108 @@
 .search-btn.active {
     background-color: var(--main-color);
     color: #ffffff;
-    font-weight: var(--bold);
+}
+
+.search_form{
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+}
+
+.search_box {
+    align-items: center;
+    position: relative;
+    width: 300px;
+    height: 40px;
+    /*margin-bottom: 20px;*/
+    display: flex;
+    flex-direction: column;
+}
+
+.search_input {
+    position: absolute;
+    height: 40px;
+    padding: 0 105px 0 10px;
+    border-radius: 12px;
+    border: none;
+    background-color: var(--hashBg-color);
+}
+
+.search_input::placeholder {
+    color: var(--main-color);
+}
+
+.clear_btn {
+    position: absolute;
+    margin-top: 8px;
+    width: 24px;
+    height: 24px;
+    right: 40px;
+    background: center / contain no-repeat
+    url("../../images/common/icons_delete.svg");
+    cursor: pointer;
+    opacity: 0;
+    z-index: -1;
+    transition: opacity 200ms ease-in-out, z-index 200ms ease-in-out;
+}
+
+.clear_btn.active {
+    opacity: 1;
+    z-index: 1;
+}
+
+.search_btn {
+    position: absolute;
+    margin-top: 8px;
+    display: block;
+    width: 24px;
+    height: 24px;
+    right: 10px;
+    background: center / contain no-repeat
+    url("../../images/common/icon_search.svg");
+    cursor: pointer;
+}
+
+.result_box {
+    padding-top: 20px;
+    padding-bottom: 60px;
+}
+
+.post_box {
+    border: 1px solid #D9DAF1;
+    border-radius: 12px;
+    margin-bottom: 24px;
+    padding: 20px;
+    cursor: pointer;
+}
+
+.post_box:hover {
+    /*border: 1px solid var(--point-color);*/
+    box-shadow: 0 2px 5px #EDEDF5;
+}
+
+.nickname_count_date {
+    display: flex;
+    justify-content: end;
+    font-size: 12px;
+}
+
+.nickname_count_date p {
+    margin-left: 20px;
+}
+
+.post_title {
+    font-size: 18px;
+    font-weight: var(--semiBold);
+    margin-bottom: 14px;
+}
+
+.post_context {
+    font-size: 16px;
+    font-weight: var(--regular);
+    margin-bottom: 10px;
+}
+
+#post_viewCount {
+    margin-left: 5px;
 }

--- a/src/main/resources/templates/user/search/result.html
+++ b/src/main/resources/templates/user/search/result.html
@@ -55,15 +55,18 @@
         <!-- 게시글 리스트 -->
         <div style="padding-top: 20px; padding-bottom: 60px">
             <div th:each="post : ${postList}">
-                <div  style="border: 1px solid #D9DAF1; border-radius: 12px; margin-bottom: 24px; padding: 10px;">
-                    <!-- 이미지 -->
-                    <div></div>
-                    <!-- 내용 -->
-                    <p th:text="${post.mainCategory}"></p>
-                    <p th:text="${post.postTitle}"></p>
-                    <p th:text="${#strings.length(post.postContext) &gt; 100} ? ${#strings.substring(post.postContext, 0, 99) + '...'} : ${post.postContext}"></p>
-                    <p th:text="${post.member.nickname}"></p>
-                    <p class="eng"><span th:text="${#dates.format(post.postDate, 'yyyy-MM-dd')}"></span></p>
+                <div  style="border: 1px solid #D9DAF1; border-radius: 12px; margin-bottom: 24px; padding: 10px; cursor: pointer">
+                    <div th:attr="onclick='redirectToDetailPage(\'' + ${post.mainCategory} + '\', \'' + ${post.postCode} + '\')'">
+
+                        <!-- 이미지 -->
+                        <div></div>
+                        <!-- 내용 -->
+                        <p th:text="${post.mainCategory}"></p>
+                        <p th:text="${post.postTitle}"></p>
+                        <p th:text="${#strings.length(post.postContext) &gt; 100} ? ${#strings.substring(post.postContext, 0, 99) + '...'} : ${post.postContext}"></p>
+                        <p th:text="${post.member.nickname}"></p>
+                        <p class="eng"><span th:text="${#dates.format(post.postDate, 'yyyy-MM-dd')}"></span></p>
+                    </div>
                 </div>
             </div>
         </div>
@@ -74,6 +77,26 @@
     <!-- //FOOTER -->
 </div>
 <script th:src="@{/js/common.js}"></script>
+<script th:inline="javascript">
+    function redirectToDetailPage(mainCategory, postCode) {
+        var url;
+        switch (mainCategory) {
+            case '리뷰':
+                url = '/board/reviewDetail?id=' + postCode;
+                break;
+            case '자유':
+                url = '/board/freeDetail?id=' + postCode;
+                break;
+            case '매거진':
+                url = '/board/magazinedetail?id=' + postCode;
+                break;
+        }
+        if (url) {
+            location.href = url;
+        }
+    }
+</script>
+
 
 </body>
 </html>

--- a/src/main/resources/templates/user/search/result.html
+++ b/src/main/resources/templates/user/search/result.html
@@ -6,12 +6,6 @@
     <link rel="stylesheet" th:href="@{/css/default.css}">
     <link rel="stylesheet" th:href="@{/css/user/common.css}">
     <link rel="stylesheet" th:href="@{/css/user/search.css}">
-    <script>
-        const message = `[[${ message }]]`;
-        if(message) {
-            alert(message);
-        }
-    </script>
 </head>
 <body>
 <div class="wrapper">
@@ -22,32 +16,32 @@
     <!-- contents -->
     <div class="search_cont">
         <!-- "키워드" 검색결과 (갯수) -->
-        <div style="padding-top: 60px; display: flex">
+        <div class="keyword_result">
             <p th:text="'&quot;' + ${keyword} + '&quot; 검색 결과'"></p>
             <!-- 검색 결과 게시글 수 -->
-            <span th:text="${count}" style="padding: 0 5px 0 5px; border-radius: 12px; background-color: var(--main-color); color: #ffffff"></span>
+            <span th:text="${count}"></span>
         </div>
         <!-- 제목, 내용 버튼 & 검색창 -->
-        <div style="display: flex">
-            <div>
+        <div class="searchType_searchBox">
+            <div class="button_box">
                 <form class="search_bar" th:action="@{/search}" method="get">
                     <input type="hidden" name="searchType" value="">
                     <input type="hidden" name="keyword" th:value="${keyword}">
-                    <button type="submit">제목+내용</button>
+                    <button type="submit" class="search-btn" id="allBtn" th:classappend="${searchType == '' ? 'active' : ''}">제목+내용</button>
                 </form>
             </div>
-            <div>
+            <div class="button_box">
                 <form class="search_bar" th:action="@{/search}" method="get">
                     <input type="hidden" name="searchType" value="title">
                     <input type="hidden" name="keyword" th:value="${keyword}">
-                    <button type="submit">제목</button>
+                    <button type="submit" class="search-btn" id="titleBtn" th:classappend="${searchType == 'title' ? 'active' : ''}">제목</button>
                 </form>
             </div>
-            <div>
+            <div class="button_box">
                 <form class="search_bar" th:action="@{/search}" method="get">
                     <input type="hidden" name="searchType" value="context">
                     <input type="hidden" name="keyword" th:value="${keyword}">
-                    <button type="submit">내용</button>
+                    <button type="submit" class="search-btn" id="contentBtn" th:classappend="${searchType == 'context' ? 'active' : ''}">내용</button>
                 </form>
             </div>
             <div></div>
@@ -64,8 +58,11 @@
                         <p th:text="${post.mainCategory}"></p>
                         <p th:text="${post.postTitle}"></p>
                         <p th:text="${#strings.length(post.postContext) &gt; 100} ? ${#strings.substring(post.postContext, 0, 99) + '...'} : ${post.postContext}"></p>
-                        <p th:text="${post.member.nickname}"></p>
-                        <p class="eng"><span th:text="${#dates.format(post.postDate, 'yyyy-MM-dd')}"></span></p>
+                        <div>
+                            <p th:text="${post.member.nickname}"></p>
+                            <p>조회<span class="eng" th:text="${post.viewCount}"></span></p>
+                            <p class="eng"><span th:text="${#dates.format(post.postDate, 'yyyy-MM-dd')}"></span></p>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -78,6 +75,35 @@
 </div>
 <script th:src="@{/js/common.js}"></script>
 <script th:inline="javascript">
+    // 페이지 로드 시 활성화 버튼에 스타일 적용
+    document.addEventListener("DOMContentLoaded", function(event) {
+        var searchType = /* 서버에서 전달한 활성화된 버튼 타입 */;
+        setActiveButton(searchType);
+    });
+
+    // 클릭된 버튼에 스타일 적용
+    function setActiveButton(buttonId) {
+        var buttons = document.querySelectorAll('.search-btn');
+        buttons.forEach(function(button) {
+            button.classList.remove('active');
+        });
+
+        var activeButton = document.getElementById(buttonId);
+        if (activeButton) {
+            activeButton.classList.add('active');
+        }
+    }
+
+    // 클릭된 버튼의 스타일 초기화 및 활성 버튼 설정
+    document.querySelectorAll('.search-bar').forEach(function(form) {
+        form.addEventListener('submit', function(event) {
+            var buttonId = event.submitter.id;
+            setActiveButton(buttonId);
+        });
+    });
+
+
+
     function redirectToDetailPage(mainCategory, postCode) {
         var url;
         switch (mainCategory) {
@@ -96,7 +122,6 @@
         }
     }
 </script>
-
 
 </body>
 </html>

--- a/src/main/resources/templates/user/search/result.html
+++ b/src/main/resources/templates/user/search/result.html
@@ -19,49 +19,62 @@
         <div class="keyword_result">
             <p th:text="'&quot;' + ${keyword} + '&quot; 검색 결과'"></p>
             <!-- 검색 결과 게시글 수 -->
-            <span th:text="${count}"></span>
+            <div class="post_count">
+                <span th:text="${count}"></span>
+            </div>
         </div>
         <!-- 제목, 내용 버튼 & 검색창 -->
         <div class="searchType_searchBox">
-            <div class="button_box">
-                <form class="search_bar" th:action="@{/search}" method="get">
-                    <input type="hidden" name="searchType" value="">
-                    <input type="hidden" name="keyword" th:value="${keyword}">
-                    <button type="submit" class="search-btn" id="allBtn" th:classappend="${searchType == '' ? 'active' : ''}">제목+내용</button>
+            <div class="buttons_outline">
+                <div class="button_box">
+                    <form class="search_bar" th:action="@{/search}" method="get">
+                        <input type="hidden" name="searchType" value="">
+                        <input type="hidden" name="keyword" th:value="${keyword}">
+                        <button type="submit" class="search-btn" id="allBtn" th:classappend="${searchType == '' ? 'active' : ''}">제목+내용</button>
+                    </form>
+                </div>
+                <div class="button_box">
+                    <form class="search_bar" th:action="@{/search}" method="get">
+                        <input type="hidden" name="searchType" value="title">
+                        <input type="hidden" name="keyword" th:value="${keyword}">
+                        <button type="submit" class="search-btn" id="titleBtn" th:classappend="${searchType == 'title' ? 'active' : ''}">제목</button>
+                    </form>
+                </div>
+                <div class="button_box">
+                    <form class="search_bar" th:action="@{/search}" method="get">
+                        <input type="hidden" name="searchType" value="context">
+                        <input type="hidden" name="keyword" th:value="${keyword}">
+                        <button type="submit" class="search-btn" id="contentBtn" th:classappend="${searchType == 'context' ? 'active' : ''}">내용</button>
+                    </form>
+                </div>
+            </div>
+            <div>
+                <form class="search_form" th:action="@{/search}" method="get">
+                    <div class="search_box">
+                        <input type="search" class="search_input" th:value="${keyword}" name="keyword">
+                        <input type="hidden" name="searchType" value="">
+                        <span class="clear_btn"></span>
+                        <span class="search_btn"></span>
+                    </div>
                 </form>
             </div>
-            <div class="button_box">
-                <form class="search_bar" th:action="@{/search}" method="get">
-                    <input type="hidden" name="searchType" value="title">
-                    <input type="hidden" name="keyword" th:value="${keyword}">
-                    <button type="submit" class="search-btn" id="titleBtn" th:classappend="${searchType == 'title' ? 'active' : ''}">제목</button>
-                </form>
-            </div>
-            <div class="button_box">
-                <form class="search_bar" th:action="@{/search}" method="get">
-                    <input type="hidden" name="searchType" value="context">
-                    <input type="hidden" name="keyword" th:value="${keyword}">
-                    <button type="submit" class="search-btn" id="contentBtn" th:classappend="${searchType == 'context' ? 'active' : ''}">내용</button>
-                </form>
-            </div>
-            <div></div>
         </div>
         <!-- 게시글 리스트 -->
-        <div style="padding-top: 20px; padding-bottom: 60px">
+        <div class="result_box">
             <div th:each="post : ${postList}">
-                <div  style="border: 1px solid #D9DAF1; border-radius: 12px; margin-bottom: 24px; padding: 10px; cursor: pointer">
+                <div class="post_box">
                     <div th:attr="onclick='redirectToDetailPage(\'' + ${post.mainCategory} + '\', \'' + ${post.postCode} + '\')'">
 
                         <!-- 이미지 -->
                         <div></div>
                         <!-- 내용 -->
-                        <p th:text="${post.mainCategory}"></p>
-                        <p th:text="${post.postTitle}"></p>
-                        <p th:text="${#strings.length(post.postContext) &gt; 100} ? ${#strings.substring(post.postContext, 0, 99) + '...'} : ${post.postContext}"></p>
-                        <div>
+<!--                        <p th:text="${post.mainCategory}"></p>-->
+                        <p class="post_title" th:text="${post.postTitle}"></p>
+                        <p class="post_context" th:text="${#strings.length(post.postContext) &gt; 100} ? ${#strings.substring(post.postContext, 0, 99) + '...'} : ${post.postContext}"></p>
+                        <div class="nickname_count_date">
                             <p th:text="${post.member.nickname}"></p>
-                            <p>조회<span class="eng" th:text="${post.viewCount}"></span></p>
                             <p class="eng"><span th:text="${#dates.format(post.postDate, 'yyyy-MM-dd')}"></span></p>
+                            <p>조회<span class="eng" id="post_viewCount" th:text="${post.viewCount}"></span></p>
                         </div>
                     </div>
                 </div>
@@ -77,7 +90,7 @@
 <script th:inline="javascript">
     // 페이지 로드 시 활성화 버튼에 스타일 적용
     document.addEventListener("DOMContentLoaded", function(event) {
-        var searchType = /* 서버에서 전달한 활성화된 버튼 타입 */;
+        var searchType = document.getElementById('searchType').value;
         setActiveButton(searchType);
     });
 
@@ -121,6 +134,24 @@
             location.href = url;
         }
     }
+</script>
+<script>
+    // 검색시 x버튼
+    const clearBtn = document.querySelector(".clear_btn");
+    clearBtn.addEventListener("click", (e) => { //x버튼 클릭시
+        e.currentTarget.parentNode.querySelector(".search_input").value = null; // 입력된 검색어 내용 null로 변경
+        clearBtn.classList.remove("active"); // x버튼 비활성화
+    });
+
+    // 검색시 입력 내용 실시간 감지 & x버튼 활성/비활성화
+    const searchInput = document.querySelector(".search_input");
+    searchInput.addEventListener("input", (e) => {
+        if (e.currentTarget.value.length > 0) {// 검색어입력내용의 길이가 0보다 큰 경우
+            clearBtn.classList.add("active"); // x버튼 활성화
+        } else if (e.currentTarget.value.length <= 0) { // 검색어입력내용의 길이가 0보다 작거나 같은 경우
+            clearBtn.classList.remove("active");// x버튼 비활성화
+        }
+    });
 </script>
 
 </body>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #130 

## 📝작업 내용

> 검색 결과 페이지 -> 게시물 상세 페이지 연결( 매거진, 자유, 리뷰)
> 제목+내용, 제목, 내용 버튼에 활성 기능 추가
> 검색 결과 페이지에 검색 창 및 검색 기능 추가
> 검색 결과 페이지에 css 적용

### 스크린샷
* 검색 유형 : 제목+내용 
![image](https://github.com/Team-Binions/Team-Binions/assets/155221216/ebe6e448-ef30-4457-ba5a-5c20d1f50e15)

* 검색 유형 : 제목 
![image](https://github.com/Team-Binions/Team-Binions/assets/155221216/85887f1c-312e-4eea-8650-cee22c2f1414)

* 검색 유형 : 내용
![image](https://github.com/Team-Binions/Team-Binions/assets/155221216/6b66d2b8-86dd-4bc0-9357-adf12cd75d18)


## 💬리뷰 요구사항(선택)
