### PR TITLE
[FEATURE][COMMENT] 댓글 버그 픽스

### DIFF
--- a/src/main/resources/templates/user/board/freeDetail.html
+++ b/src/main/resources/templates/user/board/freeDetail.html
@@ -261,8 +261,9 @@
                                 </div>
                             </div>
                             `;
+                            const authBox = li.querySelector('.auth_box');
                             if (cmt.member.nickname === currentNickname) {
-                                $(".auth_box").css('display','block');
+                                authBox.style.display = 'block';
                             }
                             commentList.appendChild(li);
                         })


### PR DESCRIPTION
## 📝작업 내용

### 댓글 버그 픽스

#### 첫번째 댓글에 수정/삭제 버튼이 활성화 되지 않는 문제
1. 비동기로 댓글목록을 가져오는 과정에서 댓글을 남긴 유저의 정보와 로그인한 세션 인증 정보가 일치하면 수정/삭제를 생성하고 아니면 숨기는 기능이 있는데 블럭 내부에서 선택자를 지정할때 기존에는 전역에 대해서 선택자를 지정해줬었기 때문에첫번째 댓글에서는 참조를 못하고 두번째 부터 참조를 하는 이슈가 있었다.
2. 해당 로직에서 댓글 목록 반복문이 돌때마다 전역대상이 아니라 내부의 선택자를 따로 지정해 주었다.
3.  해당 블록에 있는 내부 선택자와 비교를 하게한 후 해결
