### PR TITLE
[Hotfix][upload] 파일 다중 업로드 버그 이슈

### DIFF
--- a/src/main/java/com/beanions/common/uploadfiles/UploadController.java
+++ b/src/main/java/com/beanions/common/uploadfiles/UploadController.java
@@ -67,39 +67,39 @@ public class UploadController {
 
   /*파일 업로드, 업로드 결과 반환*/
   @PostMapping("/user/uploadAjax")
-  public String uploadFile(@RequestParam(value="file",required = false) MultipartFile file) throws JsonProcessingException {
-
+  public String uploadFile(@RequestParam(value = "file", required = false) MultipartFile[] files) throws JsonProcessingException {
     String root = "src/main/resources/assets/images/upload";
     String filePath = root + "/user/uploadTemp";
 
     File dir = new File(filePath);
-
-    if( !dir.exists() ) {
+    if (!dir.exists()) {
       dir.mkdirs();
     }
 
-    /* 파일명 변경하기 */
-    String originFileName = file.getOriginalFilename();
-    System.out.println("originFileName : " + originFileName);
-    String ext = originFileName.substring(originFileName.lastIndexOf("."));
-//        System.out.println("ext : " + ext);
+    List<String> savedFileNames = new ArrayList<>();
 
-    String savedName = UUID.randomUUID() + ext;
-    System.out.println("savedName : " + savedName);
+    for (MultipartFile file : files) {
+      if (file.isEmpty()) {
+        continue;
+      }
 
+      String originFileName = file.getOriginalFilename();
+      System.out.println("originFileName : " + originFileName);
+      String ext = originFileName.substring(originFileName.lastIndexOf("."));
+      String savedName = UUID.randomUUID() + ext;
+      System.out.println("savedName : " + savedName);
 
-    /* 파일 저장 */
-    try {
-      Path path= Paths.get(filePath + "/" + savedName).toAbsolutePath();
-      file.transferTo(path.toFile());
-//            file.transferTo(new File(filePath + "/" + savedName));
+      try {
+        Path path = Paths.get(filePath + "/" + savedName).toAbsolutePath();
+        file.transferTo(path.toFile());
+      } catch (IOException e) {
+        System.out.println("error : " + e);
+      }
 
-    } catch (IOException e) {
-      System.out.println("error : " + e);
+      savedFileNames.add(savedName);
     }
 
-    return new ObjectMapper().writeValueAsString(savedName);
-
+    return new ObjectMapper().writeValueAsString(savedFileNames);
   }
 
   // 비동기로 이미지 파일 보여주는 경로

--- a/src/main/resources/templates/user/mypage/fileUpload.html
+++ b/src/main/resources/templates/user/mypage/fileUpload.html
@@ -232,15 +232,15 @@
           console.log('파일업로드시 index : ' + index);
           readURL(this, index);
 
-          // 파일을 가져온다.
-          var file = event.target.files[0];
+          // 선택된 파일들을 가져온다
+          const files = this.files;
 
-          // console.log(file);
-
-          // formData객체에 파일(MultipartFile)형태 그대로 담는다
+          // formData 객체에 모든 파일을 추가
           var formData = new FormData();
-          formData.append("file",file);
-          // console.log(formData.get("file"));
+          Array.from(files).forEach(file => {
+            formData.append("file", file);
+          });
+          console.log(formData);
 
           // Fetch를 이용하여 요청을 보낸다.
           fetch("/user/uploadAjax", {
@@ -258,11 +258,14 @@
                     if(data == null) {
                       return alert("실패");
                     }
-                    const imgTmp = {};
-                    imgTmp["fileName"] = data; // "fileName"을 키로 사용하여 data를 객체에 추가
-                    imgTemp.push(imgTmp); // imgTmp 객체를 imgTemp 배열에 추가
 
-                    console.log("imgTmp:", imgTmp);
+                    // 서버에서 반환한 데이터가 여러 파일에 대한 것일 경우 처리
+                    Array.from(data).forEach(fileData => {
+                      const imgTmp = {};
+                      imgTmp["fileName"] = fileData; // "fileName"을 키로 사용하여 data를 객체에 추가
+                      imgTemp.push(imgTmp); // imgTmp 객체를 imgTemp 배열에 추가
+                    });
+
                     console.log("imgTemp:", imgTemp);
                   })
                   .catch(error => {


### PR DESCRIPTION
## 📝작업 내용

1. 업로드 중 임시폴더에 파일업로드 할 때 다중 선택이 가능하게 해놓았는데 fetch로 요청메서드 보낼때 매핑핸들러에서 MultipartFile 객체를 MultipartFile[] 배열 객체로 요청을 받았어야 했는데 처리가 안되고 있었다.
2. 배열객체로 받고 임시폴더에 파일을 반복문처리해서 저장하도록 수정하였다.
